### PR TITLE
Chore/slack review fixes

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -22,7 +22,6 @@ pub struct AppState {
     pub environment: Environment,
     pub db: Arc<Client>,
     pub jwt_secret: String,
-    pub slack_webhook_url: Option<String>,
 }
 
 impl AppState {
@@ -36,7 +35,6 @@ impl AppState {
             _ => env::var("MONGO_URI").expect("MongoURI not set"),
         };
         let jwt_secret = env::var("JWT_SECRET").expect("JWT_SECRET not set");
-        let slack_webhook_url = env::var("SLACK_WEBHOOK_URL").ok();
 
         let db = db::mongo::db_client(&db_uri).await;
 
@@ -49,7 +47,6 @@ impl AppState {
             environment,
             db,
             jwt_secret,
-            slack_webhook_url,
         }
     }
 }

--- a/src/models.rs
+++ b/src/models.rs
@@ -1,4 +1,5 @@
 pub mod auth;
 pub mod cards;
+pub mod slack;
 pub mod teams;
 pub mod users;

--- a/src/models/slack.rs
+++ b/src/models/slack.rs
@@ -1,0 +1,9 @@
+use serde::Serialize;
+
+#[derive(Debug, Serialize, Clone)]
+pub struct SlackNotificationPayload {
+    pub slack_user_id: String,
+    pub card_title: String,
+    pub card_description: Option<String>,
+    pub priority: Option<String>,
+}

--- a/src/models/teams.rs
+++ b/src/models/teams.rs
@@ -24,6 +24,7 @@ pub struct Team {
     pub description: Option<String>,
     pub leader_id: ObjectId,
     pub members: Vec<TeamMember>,
+    pub slack_webhook_url: Option<String>,
 }
 
 impl Team {
@@ -46,6 +47,7 @@ impl Team {
             description,
             leader_id,
             members: vec![leader_member],
+            slack_webhook_url: None,
         }
     }
 
@@ -119,6 +121,7 @@ pub struct CreateTeamPayload {
 pub struct UpdateTeamPayload {
     pub name: Option<String>,
     pub description: Option<String>,
+    pub slack_webhook_url: Option<String>,
 }
 
 #[derive(Debug, Deserialize)]

--- a/src/routes/teams.rs
+++ b/src/routes/teams.rs
@@ -1,9 +1,9 @@
 use crate::config::AppState;
-use crate::models::users::User;
 use crate::models::teams::{
     AddMemberPayload, CreateTeamPayload, RemoveMemberPayload, TeamResponse,
     TeamWithUsernamesResponse, TeamsResponse, UpdateTeamPayload,
 };
+use crate::models::users::User;
 use crate::services::teams::{
     add_member, create_team, delete_team, get_team, get_team_with_usernames, get_user_teams,
     leave_team, remove_member, update_team,
@@ -74,13 +74,13 @@ async fn handle_get_team(
                 }
             }
             (
-            StatusCode::OK,
-            Json(TeamResponse {
-                success: true,
-                team: Some(team),
-                message: Some("Team retrieved successfully".to_string()),
-            }),
-        )
+                StatusCode::OK,
+                Json(TeamResponse {
+                    success: true,
+                    team: Some(team),
+                    message: Some("Team retrieved successfully".to_string()),
+                }),
+            )
         }
         Ok(None) => (
             StatusCode::NOT_FOUND,

--- a/src/routes/teams.rs
+++ b/src/routes/teams.rs
@@ -1,4 +1,5 @@
 use crate::config::AppState;
+use crate::models::users::User;
 use crate::models::teams::{
     AddMemberPayload, CreateTeamPayload, RemoveMemberPayload, TeamResponse,
     TeamWithUsernamesResponse, TeamsResponse, UpdateTeamPayload,
@@ -15,6 +16,7 @@ use axum::{
     routing::{delete, get, post, put},
     Json, Router,
 };
+use mongodb::bson::doc;
 
 pub fn routes() -> Router<AppState> {
     Router::new()
@@ -59,18 +61,27 @@ async fn handle_create_team(
 
 async fn handle_get_team(
     State(state): State<AppState>,
-    AuthBearer(_user_email): AuthBearer,
+    AuthBearer(user_email): AuthBearer,
     Path(team_name): Path<String>,
 ) -> impl IntoResponse {
     match get_team(&state.db, &team_name).await {
-        Ok(Some(team)) => (
+        Ok(Some(mut team)) => {
+            // Hide webhook for non-leaders
+            let users = state.db.database("general").collection::<User>("users");
+            if let Ok(Some(user)) = users.find_one(doc! {"email": &user_email}).await {
+                if !team.is_leader(&user.id.unwrap()) {
+                    team.slack_webhook_url = None;
+                }
+            }
+            (
             StatusCode::OK,
             Json(TeamResponse {
                 success: true,
                 team: Some(team),
                 message: Some("Team retrieved successfully".to_string()),
             }),
-        ),
+        )
+        }
         Ok(None) => (
             StatusCode::NOT_FOUND,
             Json(TeamResponse {

--- a/src/services/cards.rs
+++ b/src/services/cards.rs
@@ -2,7 +2,9 @@ use crate::{
     config::AppState,
     db::mongo::{MongoService, ODM},
     models::cards::{AddCardPayload, Board, Card, DeleteCardPayload, EditCardPayload},
-    services::{slack::SlackNotification, user_info::get_user_by_username},
+    models::slack::SlackNotificationPayload,
+    models::teams::Team,
+    services::{slack::{SlackNotifier, SlackWebhookNotifier}, user_info::get_user_by_username},
     utils::errors::CustomError,
 };
 use mongodb::{bson::oid::ObjectId, Client};
@@ -36,27 +38,34 @@ pub async fn add_card(payload: AddCardPayload, app_state: &AppState) -> Result<C
         .replace_one(board, board.id.as_ref().unwrap())
         .await?;
 
-    // Send Slack notification if assignee is set
-    if let Some(webhook_url) = &app_state.slack_webhook_url {
-        if let Some(assignee) = &payload.assignee {
-            if let Ok(user) = get_user_by_username(assignee, &app_state.db).await {
-                if let Some(slack_user_id) = user.slack_user_id {
-                    let notification = SlackNotification {
-                        slack_user_id,
-                        card_title: payload.title,
-                        card_description: payload.description,
-                        priority: payload.priority,
-                    };
-
-                    if let Err(e) = crate::services::slack::send_assignee_notification(
-                        webhook_url,
-                        notification,
-                    )
-                    .await
-                    {
-                        eprintln!("Failed to send Slack notification: {}", e);
+    // Send Slack notification if team has webhook and assignee is set
+    if let Some(assignee) = &payload.assignee {
+        let teams = app_state.db.database("general").collection::<Team>("teams");
+        if let Ok(Some(team)) = teams
+            .find_one(mongodb::bson::doc! {"name": &payload.team })
+            .await
+        {
+            if let Some(webhook_url) = team.slack_webhook_url {
+                if let Ok(user) = get_user_by_username(assignee, &app_state.db).await {
+                    if let Some(slack_user_id) = user.slack_user_id {
+                        let payload = SlackNotificationPayload {
+                            slack_user_id,
+                            card_title: payload.title,
+                            card_description: payload.description,
+                            priority: payload.priority,
+                        };
+                        let notifier = SlackWebhookNotifier;
+                        if let Err(e) = notifier.send(&webhook_url, payload).await {
+                            eprintln!("Slack send failed: {}", e);
+                        }
+                    } else {
+                        eprintln!("Slack user id missing");
                     }
+                } else {
+                    eprintln!("Assignee not found");
                 }
+            } else {
+                eprintln!("Team webhook missing");
             }
         }
     }
@@ -165,27 +174,33 @@ pub async fn edit_card(
         .and_then(|col| col.cards.iter().find(|c| c.id == Some(card_oid)))
         .ok_or_else(|| CustomError::NotFound("Updated card not found".to_string()))?;
 
-    // Send Slack notification if assignee changed
-    if let Some(webhook_url) = &app_state.slack_webhook_url {
-        if old_assignee != Some(payload.assignee.clone()) {
-            if let Ok(user) = get_user_by_username(&payload.assignee, &app_state.db).await {
-                if let Some(slack_user_id) = user.slack_user_id {
-                    let notification = SlackNotification {
-                        slack_user_id,
-                        card_title: payload.title.clone(),
-                        card_description: Some(payload.description.clone()),
-                        priority: payload.priority.clone(),
-                    };
-
-                    if let Err(e) = crate::services::slack::send_assignee_notification(
-                        webhook_url,
-                        notification,
-                    )
-                    .await
-                    {
-                        eprintln!("Failed to send Slack notification: {}", e);
+    if old_assignee != Some(payload.assignee.clone()) {
+        let teams = app_state.db.database("general").collection::<Team>("teams");
+        if let Ok(Some(team)) = teams
+            .find_one(mongodb::bson::doc! {"name": &payload.team })
+            .await
+        {
+            if let Some(webhook_url) = team.slack_webhook_url {
+                if let Ok(user) = get_user_by_username(&payload.assignee, &app_state.db).await {
+                    if let Some(slack_user_id) = user.slack_user_id {
+                        let payload = SlackNotificationPayload {
+                            slack_user_id,
+                            card_title: payload.title.clone(),
+                            card_description: Some(payload.description.clone()),
+                            priority: payload.priority.clone(),
+                        };
+                        let notifier = SlackWebhookNotifier;
+                        if let Err(e) = notifier.send(&webhook_url, payload).await {
+                            eprintln!("Slack send failed: {}", e);
+                        }
+                    } else {
+                        eprintln!("Slack user id missing");
                     }
+                } else {
+                    eprintln!("Assignee not found");
                 }
+            } else {
+                eprintln!("Team webhook missing");
             }
         }
     }

--- a/src/services/cards.rs
+++ b/src/services/cards.rs
@@ -4,7 +4,10 @@ use crate::{
     models::cards::{AddCardPayload, Board, Card, DeleteCardPayload, EditCardPayload},
     models::slack::SlackNotificationPayload,
     models::teams::Team,
-    services::{slack::{SlackNotifier, SlackWebhookNotifier}, user_info::get_user_by_username},
+    services::{
+        slack::{SlackNotifier, SlackWebhookNotifier},
+        user_info::get_user_by_username,
+    },
     utils::errors::CustomError,
 };
 use mongodb::{bson::oid::ObjectId, Client};
@@ -55,17 +58,9 @@ pub async fn add_card(payload: AddCardPayload, app_state: &AppState) -> Result<C
                             priority: payload.priority,
                         };
                         let notifier = SlackWebhookNotifier;
-                        if let Err(e) = notifier.send(&webhook_url, payload).await {
-                            eprintln!("Slack send failed: {}", e);
-                        }
-                    } else {
-                        eprintln!("Slack user id missing");
+                        let _ = notifier.send(&webhook_url, payload).await;
                     }
-                } else {
-                    eprintln!("Assignee not found");
                 }
-            } else {
-                eprintln!("Team webhook missing");
             }
         }
     }
@@ -190,17 +185,9 @@ pub async fn edit_card(
                             priority: payload.priority.clone(),
                         };
                         let notifier = SlackWebhookNotifier;
-                        if let Err(e) = notifier.send(&webhook_url, payload).await {
-                            eprintln!("Slack send failed: {}", e);
-                        }
-                    } else {
-                        eprintln!("Slack user id missing");
+                        let _ = notifier.send(&webhook_url, payload).await;
                     }
-                } else {
-                    eprintln!("Assignee not found");
                 }
-            } else {
-                eprintln!("Team webhook missing");
             }
         }
     }

--- a/src/services/slack.rs
+++ b/src/services/slack.rs
@@ -1,93 +1,99 @@
+use crate::models::slack::SlackNotificationPayload;
+use crate::utils::errors::CustomError;
 use serde_json::json;
 use std::collections::HashMap;
 
-#[derive(Debug)]
-pub struct SlackNotification {
-    pub slack_user_id: String,
-    pub card_title: String,
-    pub card_description: Option<String>,
-    pub priority: Option<String>,
+#[async_trait::async_trait]
+pub trait SlackNotifier: Send + Sync {
+    fn build_message(
+        &self,
+        payload: &SlackNotificationPayload,
+    ) -> HashMap<String, serde_json::Value>;
+    async fn send(
+        &self,
+        webhook_url: &str,
+        payload: SlackNotificationPayload,
+    ) -> Result<(), CustomError>;
 }
 
-pub async fn send_assignee_notification(
-    webhook_url: &str,
-    notification: SlackNotification,
-) -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
-    let client = reqwest::Client::new();
+pub struct SlackWebhookNotifier;
 
-    let message = create_slack_message(notification);
+impl SlackWebhookNotifier {
+    fn create_message(payload: &SlackNotificationPayload) -> HashMap<String, serde_json::Value> {
+        let mut message = HashMap::new();
 
-    let response = match client.post(webhook_url).json(&message).send().await {
-        Ok(res) => res,
-        Err(e) => {
-            eprintln!("Error sending request to Slack: {}", e);
-            return Err(Box::new(e));
-        }
-    };
+        message.insert(
+            "text".to_string(),
+            json!(format!(
+                "Hey <@{}>, you've been assigned to a card!",
+                payload.slack_user_id
+            )),
+        );
 
-    if !response.status().is_success() {
-        let status = response.status();
-        let body = response.text().await.unwrap_or_default();
-        eprintln!("Slack webhook failed: {} - {}", status, body);
-        return Err(format!("Slack webhook failed: {} - {}", status, body).into());
-    }
-
-    Ok(())
-}
-
-pub fn create_slack_message(notification: SlackNotification) -> HashMap<String, serde_json::Value> {
-    let mut message = HashMap::new();
-
-    message.insert(
-        "text".to_string(),
-        json!(format!(
-            "Hey <@{}>, you've been assigned to a card!",
-            notification.slack_user_id
-        )),
-    );
-
-    let mut blocks = vec![
-        json!({
-            "type": "section",
-            "text": {
-                "type": "mrkdwn",
-                "text": format!("*<@{}> has been assigned to a card!*", notification.slack_user_id)
-            }
-        }),
-        json!({
-            "type": "divider"
-        }),
-        json!({
-            "type": "section",
-            "fields": [
-                {
+        let mut blocks = vec![
+            json!({
+                "type": "section",
+                "text": {
                     "type": "mrkdwn",
-                    "text": format!("*Card:*\n{}", notification.card_title)
-                },
-                {
-                    "type": "mrkdwn",
-                    "text": format!("*Priority:*\n{}",
-                        notification.priority.as_deref().unwrap_or("N/A"))
+                    "text": format!("*<@{}> has been assigned to a card!*", payload.slack_user_id)
                 }
-            ]
-        }),
-    ];
+            }),
+            json!({ "type": "divider" }),
+            json!({
+                "type": "section",
+                "fields": [
+                    { "type": "mrkdwn", "text": format!("*Card:*\n{}", payload.card_title) },
+                    { "type": "mrkdwn", "text": format!("*Priority:*\n{}", payload.priority.as_deref().unwrap_or("N/A")) }
+                ]
+            }),
+        ];
 
-    if let Some(description) = &notification.card_description {
-        blocks.push(json!({
-            "type": "section",
-            "text": {
-                "type": "mrkdwn",
-                "text": format!("*Description:*\n{}", description)
-            }
-        }));
+        if let Some(description) = &payload.card_description {
+            blocks.push(json!({
+                "type": "section",
+                "text": { "type": "mrkdwn", "text": format!("*Description:*\n{}", description) }
+            }));
+        }
+
+        message.insert("blocks".to_string(), json!(blocks));
+        message
+    }
+}
+
+#[async_trait::async_trait]
+impl SlackNotifier for SlackWebhookNotifier {
+    fn build_message(
+        &self,
+        payload: &SlackNotificationPayload,
+    ) -> HashMap<String, serde_json::Value> {
+        Self::create_message(payload)
     }
 
-    message.insert("blocks".to_string(), json!(blocks));
-    // Remove channel field to send to default webhook channel
-    // message.insert("channel".to_string(), json!(notification.slack_user_id));
+    async fn send(
+        &self,
+        webhook_url: &str,
+        payload: SlackNotificationPayload,
+    ) -> Result<(), CustomError> {
+        let client = reqwest::Client::new();
+        let message = Self::create_message(&payload);
+        let response = client
+            .post(webhook_url)
+            .json(&message)
+            .send()
+            .await
+            .map_err(|e| CustomError::Server(format!("Slack request error: {}", e)))?;
 
-    message
+        if !response.status().is_success() {
+            let status = response.status();
+            let body = response.text().await.unwrap_or_default();
+            return Err(CustomError::Server(format!(
+                "Slack webhook failed: {}",
+                status
+            )));
+        }
+
+        Ok(())
+    }
 }
 
 #[cfg(test)]
@@ -95,20 +101,16 @@ mod tests {
     use super::*;
 
     #[test]
-    fn test_create_slack_message() {
-        let notification = SlackNotification {
+    fn test_build_message_has_blocks() {
+        let payload = SlackNotificationPayload {
             slack_user_id: "U01ABC2DEF3".to_string(),
             card_title: "Test Card".to_string(),
             card_description: Some("Test description".to_string()),
             priority: Some("High".to_string()),
         };
 
-        let message = create_slack_message(notification);
-
-        assert!(message.contains_key("text"));
-        assert!(message.contains_key("blocks"));
-
-        let blocks = message.get("blocks").unwrap().as_array().unwrap();
-        assert_eq!(blocks.len(), 2);
+        let msg = SlackWebhookNotifier::create_message(&payload);
+        assert!(msg.contains_key("text"));
+        assert!(msg.contains_key("blocks"));
     }
 }

--- a/src/services/teams.rs
+++ b/src/services/teams.rs
@@ -191,7 +191,16 @@ pub async fn update_team(
     }
 
     if let Some(webhook) = &payload.slack_webhook_url {
-        team.slack_webhook_url = Some(webhook.clone());
+        let trimmed = webhook.trim();
+        if trimmed.is_empty() {
+            team.slack_webhook_url = None;
+        } else if !trimmed.starts_with("https://hooks.slack.com/services/") {
+            return Err(CustomError::Conflict(
+                "Invalid Slack webhook URL".to_string(),
+            ));
+        } else {
+            team.slack_webhook_url = Some(trimmed.to_string());
+        }
     }
 
     let _update_result = teams

--- a/src/services/teams.rs
+++ b/src/services/teams.rs
@@ -190,6 +190,10 @@ pub async fn update_team(
         team.description = Some(description.clone());
     }
 
+    if let Some(webhook) = &payload.slack_webhook_url {
+        team.slack_webhook_url = Some(webhook.clone());
+    }
+
     let _update_result = teams
         .replace_one(doc! { "name": team_name }, &team)
         .await


### PR DESCRIPTION
- Removed `slack_webhook_url` from `AppState` and added it to the `Team` model for better organization of team-specific settings.
- Updated the `add_card` and `edit_card` functions to utilize the team's `slack_webhook_url` for sending notifications, improving the logic for when notifications are sent based on team membership.
- Introduced a new `SlackNotifier` trait and refactored the Slack notification logic to streamline message creation and sending
- Updated the `handle_get_team` function to conditionally hide the Slack webhook URL for non-leader users.
- Improved the `update_team` function to validate the Slack webhook URL, ensuring it is not empty and starts with the correct prefix, enhancing error handling for invalid URLs.