### PR TITLE
fix(api)

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -32,12 +32,12 @@ pub fn create_app(state: AppState) -> Router {
         .allow_headers(Any);
 
     Router::new()
-        .merge(auth::routes())
+        .nest("/v1", auth::routes())
         .nest("/v1", board::routes())
         .nest("/v1", cards::routes())
         .nest("/v1", users::routes())
+        .nest("/v1/teams", teams::routes())
         .merge(health::routes())
-        .nest("/teams", teams::routes())
         .layer(cors)
         .with_state(state)
 }


### PR DESCRIPTION
unify routes under /v1 and correct teams prefix\n\n- Nest auth routes under /v1 to match frontend baseURL\n- Move teams router to /v1/teams to align with FE calls\n- Keeps board/cards/users under /v1 consistently\n\nThis resolves 404/405 errors for login and team creation and ensures board loading works in production when deployed.