### PR TITLE
refactor(EditCardPayload)

### DIFF
--- a/src/models/cards.rs
+++ b/src/models/cards.rs
@@ -85,10 +85,10 @@ pub struct DeleteCardPayload {
 pub struct EditCardPayload {
     pub card_id: String,
     pub title: String,
-    pub description: String,
+    pub description: Option<String>,
     pub column_name: String,
     pub story_point: Option<u8>,
-    pub assignee: String,
+    pub assignee: Option<String>,
     pub board_id: String,
     pub priority: Option<String>,
 }

--- a/src/services/cards.rs
+++ b/src/services/cards.rs
@@ -183,8 +183,8 @@ pub async fn edit_card(
             .ok_or_else(|| CustomError::NotFound("Card not found".to_string()))?;
 
         card.title = payload.title.clone();
-        card.description = Some(payload.description.clone());
-        card.assignee = Some(payload.assignee.clone());
+        card.description = payload.description.clone();
+        card.assignee = payload.assignee.clone();
         card.story_point = payload.story_point;
         card.priority = payload.priority.clone();
     }
@@ -203,23 +203,25 @@ pub async fn edit_card(
         .and_then(|col| col.cards.iter().find(|c| c.id == Some(card_oid)))
         .ok_or_else(|| CustomError::NotFound("Updated card not found".to_string()))?;
 
-    if old_assignee != Some(payload.assignee.clone()) {
-        let teams = app_state.db.database("general").collection::<Team>("teams");
-        if let Ok(Some(team)) = teams
-            .find_one(mongodb::bson::doc! {"name": &board.team })
-            .await
-        {
-            if let Some(webhook_url) = team.slack_webhook_url {
-                if let Ok(user) = get_user_by_username(&payload.assignee, &app_state.db).await {
-                    if let Some(slack_user_id) = user.slack_user_id {
-                        let payload = SlackNotificationPayload {
-                            slack_user_id,
-                            card_title: payload.title.clone(),
-                            card_description: Some(payload.description.clone()),
-                            priority: payload.priority.clone(),
-                        };
-                        let notifier = SlackWebhookNotifier;
-                        let _ = notifier.send(&webhook_url, payload).await;
+    if old_assignee != payload.assignee {
+        if let Some(assignee) = &payload.assignee {
+            let teams = app_state.db.database("general").collection::<Team>("teams");
+            if let Ok(Some(team)) = teams
+                .find_one(mongodb::bson::doc! {"name": &board.team })
+                .await
+            {
+                if let Some(webhook_url) = team.slack_webhook_url {
+                    if let Ok(user) = get_user_by_username(assignee, &app_state.db).await {
+                        if let Some(slack_user_id) = user.slack_user_id {
+                            let payload = SlackNotificationPayload {
+                                slack_user_id,
+                                card_title: payload.title.clone(),
+                                card_description: payload.description.clone(),
+                                priority: payload.priority.clone(),
+                            };
+                            let notifier = SlackWebhookNotifier;
+                            let _ = notifier.send(&webhook_url, payload).await;
+                        }
                     }
                 }
             }

--- a/tests/card_notification_test.rs
+++ b/tests/card_notification_test.rs
@@ -62,18 +62,18 @@ mod tests {
         let payload = EditCardPayload {
             card_id: "507f1f77bcf86cd799439011".to_string(),
             title: "Updated Card".to_string(),
-            description: "Updated description".to_string(),
+            description: Some("Updated description".to_string()),
             column_name: "In Progress".to_string(),
             story_point: Some(5),
-            assignee: "newuser".to_string(),
+            assignee: Some("newuser".to_string()),
             board_id: "507f1f77bcf86cd799439012".to_string(),
             priority: Some("Medium".to_string()),
         };
 
         assert_eq!(payload.card_id, "507f1f77bcf86cd799439011");
         assert_eq!(payload.title, "Updated Card");
-        assert_eq!(payload.description, "Updated description");
-        assert_eq!(payload.assignee, "newuser");
+        assert_eq!(payload.description, Some("Updated description".to_string()));
+        assert_eq!(payload.assignee, Some("newuser".to_string()));
         assert_eq!(payload.board_id, "507f1f77bcf86cd799439012");
     }
 


### PR DESCRIPTION
change description and assignee fields to be optional\n\n- Updated `EditCardPayload` struct to make `description` and `assignee` fields optional, allowing for more flexible card editing.\n- Adjusted `edit_card` function to handle optional values correctly, ensuring proper Slack notification logic when assignee changes.