### PR TITLE
feat: implement comprehensive permission system for teams and boards

### DIFF
--- a/src/routes/board.rs
+++ b/src/routes/board.rs
@@ -1,9 +1,14 @@
 use crate::{
     config::AppState,
     models::cards::{Board, BoardIdQuery, TeamQuery},
-    services::board::{
-        create_board, delete_board, get_board_by_id, get_boards_by_team, update_board,
+    services::{
+        board::{create_board, delete_board, get_boards_by_team, update_board},
+        permission::{
+            check_board_access, require_board_write_permission, require_team_leader,
+            require_team_membership,
+        },
     },
+    utils::jwt::AuthBearer,
 };
 use axum::{
     extract::{Query, State},
@@ -35,9 +40,10 @@ pub fn routes() -> Router<AppState> {
 
 async fn handle_get_board(
     State(state): State<AppState>,
+    AuthBearer(user_email): AuthBearer,
     Query(payload): Query<BoardIdQuery>,
 ) -> impl IntoResponse {
-    match get_board_by_id(payload.board_id, &state.db).await {
+    match check_board_access(&state.db, &user_email, &payload.board_id).await {
         Ok(board) => (StatusCode::OK, Json(board)).into_response(),
         Err(e) => (e.to_status_code(), Json(e.to_error_response())).into_response(),
     }
@@ -45,8 +51,13 @@ async fn handle_get_board(
 
 async fn handle_get_boards(
     State(state): State<AppState>,
+    AuthBearer(user_email): AuthBearer,
     Query(payload): Query<TeamQuery>,
 ) -> impl IntoResponse {
+    if let Err(e) = require_team_membership(&state.db, &user_email, &payload.team).await {
+        return (e.to_status_code(), Json(e.to_error_response())).into_response();
+    }
+
     match get_boards_by_team(payload.team, &state.db).await {
         Ok(boards) => (StatusCode::OK, Json(boards)).into_response(),
         Err(e) => (e.to_status_code(), Json(e.to_error_response())).into_response(),
@@ -55,8 +66,13 @@ async fn handle_get_boards(
 
 async fn handle_create_board(
     State(state): State<AppState>,
+    AuthBearer(user_email): AuthBearer,
     Json(payload): Json<CreateBoardPayload>,
 ) -> impl IntoResponse {
+    if let Err(e) = require_team_membership(&state.db, &user_email, &payload.team).await {
+        return (e.to_status_code(), Json(e.to_error_response())).into_response();
+    }
+
     match create_board(payload.team, payload.board_name, &state.db).await {
         Ok(board) => (StatusCode::CREATED, Json(board)).into_response(),
         Err(e) => (e.to_status_code(), Json(e.to_error_response())).into_response(),
@@ -65,8 +81,21 @@ async fn handle_create_board(
 
 async fn handle_update_board(
     State(state): State<AppState>,
+    AuthBearer(user_email): AuthBearer,
     Json(payload): Json<UpdateBoardQuery>,
 ) -> impl IntoResponse {
+    let board_id = match &payload.board.id {
+        Some(id) => id.to_hex(),
+        None => {
+            let err = crate::utils::errors::CustomError::NotFound("Board ID required".to_string());
+            return (err.to_status_code(), Json(err.to_error_response())).into_response();
+        }
+    };
+
+    if let Err(e) = require_board_write_permission(&state.db, &user_email, &board_id).await {
+        return (e.to_status_code(), Json(e.to_error_response())).into_response();
+    }
+
     match update_board(payload.board, &state.db).await {
         Ok(board) => (StatusCode::OK, Json(board)).into_response(),
         Err(e) => (e.to_status_code(), Json(e.to_error_response())).into_response(),
@@ -75,8 +104,18 @@ async fn handle_update_board(
 
 async fn handle_delete_board(
     State(state): State<AppState>,
+    AuthBearer(user_email): AuthBearer,
     Query(payload): Query<BoardIdQuery>,
 ) -> impl IntoResponse {
+    let board = match check_board_access(&state.db, &user_email, &payload.board_id).await {
+        Ok(b) => b,
+        Err(e) => return (e.to_status_code(), Json(e.to_error_response())).into_response(),
+    };
+
+    if let Err(e) = require_team_leader(&state.db, &user_email, &board.team).await {
+        return (e.to_status_code(), Json(e.to_error_response())).into_response();
+    }
+
     match delete_board(payload.board_id, &state.db).await {
         Ok(_) => StatusCode::NO_CONTENT.into_response(),
         Err(e) => (e.to_status_code(), Json(e.to_error_response())).into_response(),

--- a/src/routes/cards.rs
+++ b/src/routes/cards.rs
@@ -9,7 +9,11 @@ use axum::{
 use crate::{
     config::AppState,
     models::cards::{AddCardPayload, BoardIdQuery, DeleteCardPayload, EditCardPayload},
-    services::cards::{add_card, delete_card, edit_card, get_columns},
+    services::{
+        cards::{add_card, delete_card, edit_card, get_columns},
+        permission::{check_board_access, require_board_write_permission},
+    },
+    utils::jwt::AuthBearer,
 };
 
 pub fn routes() -> Router<AppState> {
@@ -22,8 +26,14 @@ pub fn routes() -> Router<AppState> {
 
 pub async fn handle_add_card(
     State(state): State<AppState>,
+    AuthBearer(user_email): AuthBearer,
     Json(payload): Json<AddCardPayload>,
 ) -> impl IntoResponse {
+    if let Err(e) = require_board_write_permission(&state.db, &user_email, &payload.board_id).await
+    {
+        return (e.to_status_code(), Json(e.to_error_response())).into_response();
+    }
+
     match add_card(payload, &state).await {
         Ok(card) => (StatusCode::CREATED, Json(card)).into_response(),
         Err(e) => (e.to_status_code(), Json(e.to_error_response())).into_response(),
@@ -32,8 +42,13 @@ pub async fn handle_add_card(
 
 pub async fn handle_get_columns(
     State(state): State<AppState>,
+    AuthBearer(user_email): AuthBearer,
     Query(query): Query<BoardIdQuery>,
 ) -> impl IntoResponse {
+    if let Err(e) = check_board_access(&state.db, &user_email, &query.board_id).await {
+        return (e.to_status_code(), Json(e.to_error_response())).into_response();
+    }
+
     match get_columns(&query.board_id, &state.db).await {
         Ok(columns) => (StatusCode::OK, Json(columns)).into_response(),
         Err(e) => (e.to_status_code(), Json(e.to_error_response())).into_response(),
@@ -42,8 +57,14 @@ pub async fn handle_get_columns(
 
 pub async fn handle_delete_card(
     State(state): State<AppState>,
+    AuthBearer(user_email): AuthBearer,
     Json(payload): Json<DeleteCardPayload>,
 ) -> impl IntoResponse {
+    if let Err(e) = require_board_write_permission(&state.db, &user_email, &payload.board_id).await
+    {
+        return (e.to_status_code(), Json(e.to_error_response())).into_response();
+    }
+
     match delete_card(payload, &state.db).await {
         Ok(_) => StatusCode::NO_CONTENT.into_response(),
         Err(e) => (e.to_status_code(), Json(e.to_error_response())).into_response(),
@@ -52,8 +73,14 @@ pub async fn handle_delete_card(
 
 pub async fn handle_edit_card(
     State(state): State<AppState>,
+    AuthBearer(user_email): AuthBearer,
     Json(payload): Json<EditCardPayload>,
 ) -> impl IntoResponse {
+    if let Err(e) = require_board_write_permission(&state.db, &user_email, &payload.board_id).await
+    {
+        return (e.to_status_code(), Json(e.to_error_response())).into_response();
+    }
+
     match edit_card(payload, &state).await {
         Ok(card) => (StatusCode::OK, Json(card)).into_response(),
         Err(e) => (e.to_status_code(), Json(e.to_error_response())).into_response(),

--- a/src/routes/teams.rs
+++ b/src/routes/teams.rs
@@ -4,6 +4,7 @@ use crate::models::teams::{
     TeamWithUsernamesResponse, TeamsResponse, UpdateTeamPayload,
 };
 use crate::models::users::User;
+use crate::services::permission::require_team_membership;
 use crate::services::teams::{
     add_member, create_team, delete_team, get_team, get_team_with_usernames, get_user_teams,
     leave_team, remove_member, update_team,
@@ -64,9 +65,19 @@ async fn handle_get_team(
     AuthBearer(user_email): AuthBearer,
     Path(team_name): Path<String>,
 ) -> impl IntoResponse {
+    if let Err(e) = require_team_membership(&state.db, &user_email, &team_name).await {
+        return (
+            e.to_status_code(),
+            Json(TeamResponse {
+                success: false,
+                team: None,
+                message: Some(e.to_string()),
+            }),
+        );
+    }
+
     match get_team(&state.db, &team_name).await {
         Ok(Some(mut team)) => {
-            // Hide webhook for non-leaders
             let users = state.db.database("general").collection::<User>("users");
             if let Ok(Some(user)) = users.find_one(doc! {"email": &user_email}).await {
                 if !team.is_leader(&user.id.unwrap()) {
@@ -251,9 +262,20 @@ async fn handle_delete_team(
 
 async fn handle_get_team_with_usernames(
     State(state): State<AppState>,
-    AuthBearer(_user_email): AuthBearer,
+    AuthBearer(user_email): AuthBearer,
     Path(team_name): Path<String>,
 ) -> impl IntoResponse {
+    if let Err(e) = require_team_membership(&state.db, &user_email, &team_name).await {
+        return (
+            e.to_status_code(),
+            Json(TeamWithUsernamesResponse {
+                success: false,
+                team: None,
+                message: Some(e.to_string()),
+            }),
+        );
+    }
+
     match get_team_with_usernames(&state.db, &team_name).await {
         Ok(Some(team)) => (
             StatusCode::OK,

--- a/src/services.rs
+++ b/src/services.rs
@@ -1,6 +1,7 @@
 pub mod auth;
 pub mod board;
 pub mod cards;
+pub mod permission;
 pub mod slack;
 pub mod teams;
 pub mod user_info;

--- a/src/services/permission.rs
+++ b/src/services/permission.rs
@@ -1,0 +1,152 @@
+use mongodb::{bson::doc, Client};
+
+use crate::{
+    models::{cards::Board, teams::Team, users::User},
+    utils::errors::CustomError,
+};
+
+pub async fn get_user_by_email(db: &Client, email: &str) -> Result<User, CustomError> {
+    let users = db.database("general").collection::<User>("users");
+
+    users
+        .find_one(doc! { "email": email })
+        .await
+        .map_err(|e| CustomError::Database(format!("Failed to find user: {}", e)))?
+        .ok_or_else(|| CustomError::NotFound("User not found".to_string()))
+}
+
+pub async fn get_team_by_name(db: &Client, team_name: &str) -> Result<Team, CustomError> {
+    let teams = db.database("general").collection::<Team>("teams");
+
+    teams
+        .find_one(doc! { "name": team_name })
+        .await
+        .map_err(|e| CustomError::Database(format!("Failed to find team: {}", e)))?
+        .ok_or_else(|| CustomError::NotFound("Team not found".to_string()))
+}
+
+pub async fn check_team_membership(
+    db: &Client,
+    user_email: &str,
+    team_name: &str,
+) -> Result<bool, CustomError> {
+    let user = get_user_by_email(db, user_email).await?;
+    let team = get_team_by_name(db, team_name).await?;
+
+    let user_id = user
+        .id
+        .ok_or_else(|| CustomError::Server("User ID not found".to_string()))?;
+
+    Ok(team.is_member(&user_id))
+}
+
+pub async fn require_team_membership(
+    db: &Client,
+    user_email: &str,
+    team_name: &str,
+) -> Result<(), CustomError> {
+    if !check_team_membership(db, user_email, team_name).await? {
+        return Err(CustomError::Forbidden(format!(
+            "You are not a member of team '{}'",
+            team_name
+        )));
+    }
+    Ok(())
+}
+
+pub async fn check_team_permission(
+    db: &Client,
+    user_email: &str,
+    team_name: &str,
+    permission: &str,
+) -> Result<bool, CustomError> {
+    let user = get_user_by_email(db, user_email).await?;
+    let team = get_team_by_name(db, team_name).await?;
+
+    let user_id = user
+        .id
+        .ok_or_else(|| CustomError::Server("User ID not found".to_string()))?;
+
+    let member = team.members.iter().find(|m| m.user_id == user_id);
+
+    match member {
+        Some(m) => Ok(m.permissions.contains(&permission.to_string())),
+        None => Ok(false),
+    }
+}
+
+pub async fn require_team_permission(
+    db: &Client,
+    user_email: &str,
+    team_name: &str,
+    permission: &str,
+) -> Result<(), CustomError> {
+    if !check_team_permission(db, user_email, team_name, permission).await? {
+        return Err(CustomError::Forbidden(format!(
+            "You don't have '{}' permission for team '{}'",
+            permission, team_name
+        )));
+    }
+    Ok(())
+}
+
+pub async fn check_board_access(
+    db: &Client,
+    user_email: &str,
+    board_id: &str,
+) -> Result<Board, CustomError> {
+    let boards = db.database("general").collection::<Board>("boards");
+
+    let board_oid = mongodb::bson::oid::ObjectId::parse_str(board_id)
+        .map_err(|_| CustomError::NotFound("Invalid board ID".to_string()))?;
+
+    let board = boards
+        .find_one(doc! { "_id": board_oid })
+        .await
+        .map_err(|e| CustomError::Database(format!("Failed to find board: {}", e)))?
+        .ok_or_else(|| CustomError::NotFound("Board not found".to_string()))?;
+
+    require_team_membership(db, user_email, &board.team).await?;
+
+    Ok(board)
+}
+
+pub async fn require_board_write_permission(
+    db: &Client,
+    user_email: &str,
+    board_id: &str,
+) -> Result<Board, CustomError> {
+    let board = check_board_access(db, user_email, board_id).await?;
+
+    require_team_permission(db, user_email, &board.team, "write").await?;
+
+    Ok(board)
+}
+
+pub async fn check_is_team_leader(
+    db: &Client,
+    user_email: &str,
+    team_name: &str,
+) -> Result<bool, CustomError> {
+    let user = get_user_by_email(db, user_email).await?;
+    let team = get_team_by_name(db, team_name).await?;
+
+    let user_id = user
+        .id
+        .ok_or_else(|| CustomError::Server("User ID not found".to_string()))?;
+
+    Ok(team.is_leader(&user_id))
+}
+
+pub async fn require_team_leader(
+    db: &Client,
+    user_email: &str,
+    team_name: &str,
+) -> Result<(), CustomError> {
+    if !check_is_team_leader(db, user_email, team_name).await? {
+        return Err(CustomError::Forbidden(
+            "Only team leader can perform this action".to_string(),
+        ));
+    }
+    Ok(())
+}

--- a/src/utils/errors.rs
+++ b/src/utils/errors.rs
@@ -20,6 +20,7 @@ pub struct ErrorDetail {
 pub enum CustomError {
     Database(String),
     Authentication(String),
+    Forbidden(String),
     Server(String),
     NotFound(String),
     Conflict(String),
@@ -31,6 +32,7 @@ impl CustomError {
         match self {
             CustomError::Database(_) => StatusCode::INTERNAL_SERVER_ERROR,
             CustomError::Authentication(_) => StatusCode::UNAUTHORIZED,
+            CustomError::Forbidden(_) => StatusCode::FORBIDDEN,
             CustomError::Server(_) => StatusCode::INTERNAL_SERVER_ERROR,
             CustomError::NotFound(_) => StatusCode::NOT_FOUND,
             CustomError::Conflict(_) => StatusCode::CONFLICT,
@@ -49,6 +51,12 @@ impl CustomError {
             CustomError::Authentication(msg) => (
                 "AUTHENTICATION_ERROR".to_string(),
                 "Invalid email or password".to_string(),
+                Some(msg.clone()),
+                None,
+            ),
+            CustomError::Forbidden(msg) => (
+                "FORBIDDEN".to_string(),
+                "Access denied".to_string(),
                 Some(msg.clone()),
                 None,
             ),
@@ -96,6 +104,7 @@ impl std::fmt::Display for CustomError {
         match self {
             CustomError::Database(msg) => write!(f, "Database error: {}", msg),
             CustomError::Authentication(msg) => write!(f, "Authentication error: {}", msg),
+            CustomError::Forbidden(msg) => write!(f, "Forbidden: {}", msg),
             CustomError::Server(msg) => write!(f, "Server error: {}", msg),
             CustomError::NotFound(msg) => write!(f, "Not found: {}", msg),
             CustomError::Conflict(msg) => write!(f, "Conflict: {}", msg),


### PR DESCRIPTION
- Add `Forbidden` error type (HTTP 403) to `CustomError` enum
- Create `permission` service module with team/board access checking functions
- Protect all board routes with `AuthBearer` and permission checks
- Protect all card routes with `AuthBearer` and write permission checks
- Add membership verification to team GET endpoints